### PR TITLE
2 improvements for mobile devices

### DIFF
--- a/src/Map.ContextMenu.js
+++ b/src/Map.ContextMenu.js
@@ -3,7 +3,6 @@ L.Map.mergeOptions({
 });
 
 L.Map.ContextMenu = L.Handler.extend({
-
 	_touchstart: L.Browser.msPointer ? 'MSPointerDown' : L.Browser.pointer ? 'pointerdown' : 'touchstart',
 
 	statics: {
@@ -23,7 +22,7 @@ L.Map.ContextMenu = L.Handler.extend({
 		if (map.options.contextmenuWidth) {
 			container.style.width = map.options.contextmenuWidth + 'px';
 		}
-		
+
 		this._createItems();
 
 		L.DomEvent
@@ -34,16 +33,16 @@ L.Map.ContextMenu = L.Handler.extend({
 	},
 
 	addHooks: function () {
-        var container = this._map.getContainer();
-        
+		var container = this._map.getContainer();
+
 		L.DomEvent
-            .on(container, 'mouseleave', this._hide, this)
+			.on(container, 'mouseleave', this._hide, this)
 			.on(document, 'keydown', this._onKeyDown, this);
 
-        if (L.Browser.touch) {
-            L.DomEvent.on(document, this._touchstart, this._hide, this);
-        }
-        
+		if (L.Browser.touch) {
+			L.DomEvent.on(document, this._touchstart, this._hide, this);
+		}
+
 		this._map.on({
 			contextmenu: this._show,
 			mousedown: this._hide,
@@ -53,15 +52,15 @@ L.Map.ContextMenu = L.Handler.extend({
 	},
 
 	removeHooks: function () {
-        var container = this._map.getContainer();
-        
+		var container = this._map.getContainer();
+
 		L.DomEvent
-            .off(container, 'mouseleave', this._hide, this)			
+			.off(container, 'mouseleave', this._hide, this)
 			.off(document, 'keydown', this._onKeyDown, this);
 
-        if (L.Browser.touch) {
-            L.DomEvent.off(document, this._touchstart, this._hide, this);
-        }        
+		if (L.Browser.touch) {
+			L.DomEvent.off(document, this._touchstart, this._hide, this);
+		}
 
 		this._map.off({
 			contextmenu: this._show,
@@ -87,10 +86,10 @@ L.Map.ContextMenu = L.Handler.extend({
 	},
 
 	insertItem: function (options, index) {
-		index = index !== undefined ? index: this._items.length; 
+		index = index !== undefined ? index: this._items.length;
 
 		var item = this._createItem(this._container, options, index);
-		
+
 		this._items.push(item);
 
 		this._sizeChanged = true;
@@ -120,7 +119,7 @@ L.Map.ContextMenu = L.Handler.extend({
 				contextmenu: this,
 				el: item
 			});
-		}		
+		}
 	},
 
 	removeAllItems: function () {
@@ -147,7 +146,7 @@ L.Map.ContextMenu = L.Handler.extend({
 		for (i = 0, l = this._items.length; i < l; i++) {
 			item = this._items[i];
 			item.el.style.display = '';
-		}		
+		}
 	},
 
 	setDisabled: function (item, disabled) {
@@ -171,7 +170,7 @@ L.Map.ContextMenu = L.Handler.extend({
 					contextmenu: this,
 					el: item
 				});
-			}			
+			}
 		}
 	},
 
@@ -181,8 +180,8 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_createItems: function () {
 		var itemOptions = this._map.options.contextmenuItems,
-		    item,
-		    i, l;
+			item,
+			i, l;
 
 		for (i = 0, l = itemOptions.length; i < l; i++) {
 			this._items.push(this._createItem(this._container, itemOptions[i]));
@@ -194,19 +193,19 @@ L.Map.ContextMenu = L.Handler.extend({
 			return this._createSeparator(container, index);
 		}
 
-		var itemCls = L.Map.ContextMenu.BASE_CLS + '-item', 
-		    cls = options.disabled ? (itemCls + ' ' + itemCls + '-disabled') : itemCls,
-		    el = this._insertElementAt('a', cls, container, index),
-		    callback = this._createEventHandler(el, options.callback, options.context, options.hideOnSelect),
-		    html = '';
-		
+		var itemCls = L.Map.ContextMenu.BASE_CLS + '-item',
+			cls = options.disabled ? (itemCls + ' ' + itemCls + '-disabled') : itemCls,
+			el = this._insertElementAt('a', cls, container, index),
+			callback = this._createEventHandler(el, options.callback, options.context, options.hideOnSelect),
+			html = '';
+
 		if (options.icon) {
 			html = '<img class="' + L.Map.ContextMenu.BASE_CLS + '-icon" src="' + options.icon + '"/>';
 		} else if (options.iconCls) {
 			html = '<span class="' + L.Map.ContextMenu.BASE_CLS + '-icon ' + options.iconCls + '"></span>';
 		}
 
-		el.innerHTML = html + options.text;		
+		el.innerHTML = html + options.text;
 		el.href = '#';
 
 		L.DomEvent
@@ -215,9 +214,14 @@ L.Map.ContextMenu = L.Handler.extend({
 			.on(el, 'mousedown', L.DomEvent.stopPropagation)
 			.on(el, 'click', callback);
 
-        if (L.Browser.touch) {
-            L.DomEvent.on(el, this._touchstart, L.DomEvent.stopPropagation);
-        }
+		if (L.Browser.touch) {
+			L.DomEvent.on(el, this._touchstart, L.DomEvent.stopPropagation);
+		}
+
+		// Devices without a mouse fire "mouseover" on tap, but never “mouseout"
+		if (!L.Browser.pointer) {
+			L.DomEvent.on(el, 'click', this._onItemMouseOut, this);
+		}
 
 		return {
 			id: L.Util.stamp(el),
@@ -228,8 +232,8 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_removeItem: function (id) {
 		var item,
-		    el,
-		    i, l, callback;
+			el,
+			i, l, callback;
 
 		for (i = 0, l = this._items.length; i < l; i++) {
 			item = this._items[i];
@@ -245,11 +249,15 @@ L.Map.ContextMenu = L.Handler.extend({
 						.off(el, 'mousedown', L.DomEvent.stopPropagation)
 						.off(el, 'click', callback);
 
-                    if (L.Browser.touch) {
-                        L.DomEvent.off(el, this._touchstart, L.DomEvent.stopPropagation);
-                    }
+					if (L.Browser.touch) {
+						L.DomEvent.off(el, this._touchstart, L.DomEvent.stopPropagation);
+					}
+
+					if (!L.Browser.pointer) {
+						L.DomEvent.on(el, 'click', this._onItemMouseOut, this);
+					}
 				}
-				
+
 				this._container.removeChild(el);
 				this._items.splice(i, 1);
 
@@ -261,7 +269,7 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_createSeparator: function (container, index) {
 		var el = this._insertElementAt('div', L.Map.ContextMenu.BASE_CLS + '-separator', container, index);
-		
+
 		return {
 			id: L.Util.stamp(el),
 			el: el
@@ -270,21 +278,21 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_createEventHandler: function (el, func, context, hideOnSelect) {
 		var me = this,
-		    map = this._map,
-		    disabledCls = L.Map.ContextMenu.BASE_CLS + '-item-disabled',
-		    hideOnSelect = (hideOnSelect !== undefined) ? hideOnSelect : true;
-		
+			map = this._map,
+			disabledCls = L.Map.ContextMenu.BASE_CLS + '-item-disabled',
+			hideOnSelect = (hideOnSelect !== undefined) ? hideOnSelect : true;
+
 		return function (e) {
 			if (L.DomUtil.hasClass(el, disabledCls)) {
 				return;
 			}
-			
+
 			if (hideOnSelect) {
-				me._hide();			
+				me._hide();
 			}
 
 			if (func) {
-				func.call(context || map, me._showLocation);			
+				func.call(context || map, me._showLocation);
 			}
 
 			me._map.fire('contextmenu:select', {
@@ -296,7 +304,7 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_insertElementAt: function (tagName, className, container, index) {
 		var refEl,
-		    el = document.createElement(tagName);
+			el = document.createElement(tagName);
 
 		el.className = className;
 
@@ -323,31 +331,29 @@ L.Map.ContextMenu = L.Handler.extend({
 			layerPoint = map.containerPointToLayerPoint(pt),
 			latlng = map.layerPointToLatLng(layerPoint),
 			event = L.extend(data || {}, {contextmenu: this});
-			
+
 			this._showLocation = {
 				latlng: latlng,
 				layerPoint: layerPoint,
 				containerPoint: pt
 			};
 
-			if(data && data.relatedTarget){
+			if (data && data.relatedTarget){
 				this._showLocation.relatedTarget = data.relatedTarget;
 			}
 
-			this._setPosition(pt);			
+			this._setPosition(pt);
 
 			if (!this._visible) {
-				this._container.style.display = 'block';							
-				this._visible = true;							
-			} else {
-				this._setPosition(pt);			
+				this._container.style.display = 'block';
+				this._visible = true;
 			}
 
 			this._map.fire('contextmenu.show', event);
 		}
 	},
 
-	_hide: function () {        
+	_hide: function () {
 		if (this._visible) {
 			this._visible = false;
 			this._container.style.display = 'none';
@@ -357,9 +363,9 @@ L.Map.ContextMenu = L.Handler.extend({
 
 	_setPosition: function (pt) {
 		var mapSize = this._map.getSize(),
-		    container = this._container,
-		    containerSize = this._getElementSize(container),
-		    anchor;
+			container = this._container,
+			containerSize = this._getElementSize(container),
+			anchor;
 
 		if (this._map.options.contextmenuAnchor) {
 			anchor = L.point(this._map.options.contextmenuAnchor);
@@ -370,24 +376,24 @@ L.Map.ContextMenu = L.Handler.extend({
 
 		if (pt.x + containerSize.x > mapSize.x) {
 			container.style.left = 'auto';
-			container.style.right = Math.max(mapSize.x - pt.x, 0) + 'px';
+			container.style.right = Math.min(Math.max(mapSize.x - pt.x, 0), mapSize.x - containerSize.x - 1) + 'px';
 		} else {
 			container.style.left = Math.max(pt.x, 0) + 'px';
 			container.style.right = 'auto';
 		}
-		
+
 		if (pt.y + containerSize.y > mapSize.y) {
 			container.style.top = 'auto';
-			container.style.bottom = Math.max(mapSize.y - pt.y, 0) + 'px';
+			container.style.bottom = Math.min(Math.max(mapSize.y - pt.y, 0), mapSize.y - containerSize.y - 1) + 'px';
 		} else {
 			container.style.top = Math.max(pt.y, 0) + 'px';
 			container.style.bottom = 'auto';
 		}
 	},
 
-	_getElementSize: function (el) {		
+	_getElementSize: function (el) {
 		var size = this._size,
-		    initialDisplay = el.style.display;
+			initialDisplay = el.style.display;
 
 		if (!size || this._sizeChanged) {
 			size = {};
@@ -395,13 +401,13 @@ L.Map.ContextMenu = L.Handler.extend({
 			el.style.left = '-999999px';
 			el.style.right = 'auto';
 			el.style.display = 'block';
-			
+
 			size.x = el.offsetWidth;
 			size.y = el.offsetHeight;
-			
+
 			el.style.left = 'auto';
 			el.style.display = initialDisplay;
-			
+
 			this._sizeChanged = false;
 		}
 
@@ -411,7 +417,7 @@ L.Map.ContextMenu = L.Handler.extend({
 	_onKeyDown: function (e) {
 		var key = e.keyCode;
 
-		// If ESC pressed and context menu is visible hide it 
+		// If ESC pressed and context menu is visible hide it
 		if (key === 27) {
 			this._hide();
 		}

--- a/src/Mixin.ContextMenu.js
+++ b/src/Mixin.ContextMenu.js
@@ -1,5 +1,4 @@
 L.Mixin.ContextMenu = {
-
 	bindContextMenu: function (options) {
 		L.setOptions(this, options);
 		this._initContextMenu();
@@ -18,37 +17,37 @@ L.Mixin.ContextMenu = {
 	},
 
 	removeContextMenuItemWithIndex: function (index) {
-		  var items = [];
-			for (var i = 0; i < this.options.contextmenuItems.length; i++) {
-					if(this.options.contextmenuItems[i].index == index){
-							items.push(i);
-					}
+		var items = [];
+		for (var i = 0; i < this.options.contextmenuItems.length; i++) {
+			if (this.options.contextmenuItems[i].index == index){
+				items.push(i);
 			}
-			var elem = items.pop();
-			while (elem !== undefined) {
-				  this.options.contextmenuItems.splice(elem,1);
-					elem = items.pop();
-		  }
+		}
+		var elem = items.pop();
+		while (elem !== undefined) {
+			this.options.contextmenuItems.splice(elem,1);
+			elem = items.pop();
+		}
 	},
 
 	replaceContextMenuItem: function (item) {
-		  this.removeContextMenuItemWithIndex(item.index);
-		  this.addContextMenuItem(item);
+		this.removeContextMenuItemWithIndex(item.index);
+		this.addContextMenuItem(item);
 	},
 
 	_initContextMenu: function () {
 		this._items = [];
-	
+
 		this.on('contextmenu', this._showContextMenu, this);
 	},
 
 	_showContextMenu: function (e) {
 		var itemOptions,
-		    data, pt, i, l;
+			data, pt, i, l;
 
 		if (this._map.contextmenu) {
-            data = L.extend({relatedTarget: this}, e)
-            
+			data = L.extend({relatedTarget: this}, e);
+
 			pt = this._map.mouseEventToContainerPoint(e.originalEvent);
 
 			if (!this.options.contextmenuInheritItems) {
@@ -61,7 +60,7 @@ L.Mixin.ContextMenu = {
 			}
 
 			this._map.once('contextmenu.hide', this._hideContextMenu, this);
-		
+
 			this._map.contextmenu.showAt(pt, data);
 		}
 	},
@@ -72,21 +71,21 @@ L.Mixin.ContextMenu = {
 		for (i = 0, l = this._items.length; i < l; i++) {
 			this._map.contextmenu.removeItem(this._items[i]);
 		}
-		this._items.length = 0;		
+		this._items.length = 0;
 
 		if (!this.options.contextmenuInheritItems) {
 			this._map.contextmenu.showAllItems();
 		}
-	}	
+	}
 };
 
 var classes = [L.Marker, L.Path],
-    defaultOptions = {
+	defaultOptions = {
 		contextmenu: false,
 		contextmenuItems: [],
-	    contextmenuInheritItems: true
+		contextmenuInheritItems: true
 	},
-    cls, i, l;
+	cls, i, l;
 
 for (i = 0, l = classes.length; i < l; i++) {
 	cls = classes[i];

--- a/src/copyright.js
+++ b/src/copyright.js
@@ -2,7 +2,7 @@
 	Leaflet.contextmenu, a context menu for Leaflet.
 	(c) 2015, Adam Ratcliffe, GeoSmart Maps Limited
 
-        @preserve
+	@preserve
 */
 
 (function(factory) {

--- a/src/end.js
+++ b/src/end.js
@@ -1,2 +1,2 @@
-	return L.Map.ContextMenu;
-	});
+return L.Map.ContextMenu;
+});


### PR DESCRIPTION
1) Devices (e.g. mobile phone) without a mouse fire `mouseover` events on user tap, but never `mouseout` events. When a context menu is re-opened, the last used item still appears as selected. This PR fixes this, by calling `_onItemMouseOut()` when an item is selected on devices without pointer support.

2) On small screens, when the context menu is wider than half the map viewport, and the menu is opened on a point near the center in the left side of the viewport, currently:

- When there is no fixed menu width defined, the menu is shrunk so it fits:
![screenshot_20161111-031606](https://cloud.githubusercontent.com/assets/1116761/20203859/2282d084-a7cb-11e6-9ccf-a1be7cc0b8c4.png)

- When menu has fixed width defined, a part is hidden on the left side of viewport.

This PR fixes this, by pushing the menu on the right so it just fits in the viewport:
![screenshot_20161111-031338](https://cloud.githubusercontent.com/assets/1116761/20203854/1d28d4bc-a7cb-11e6-9886-a691546e6e39.png)

+ Remove a useless `_setPosition(pt)` call. Is executed unconditionally 3 lines earlier.

+ Code cosmetic: Consistently use tabs for indentation.