### PR TITLE
default relatedTarget to map so its object can be accessed directly from the callback event

### DIFF
--- a/src/Map.ContextMenu.js
+++ b/src/Map.ContextMenu.js
@@ -297,7 +297,7 @@ L.Map.ContextMenu = L.Handler.extend({
                 containerPoint = me._showLocation.containerPoint,
                 layerPoint = map.containerPointToLayerPoint(containerPoint),
                 latlng = map.layerPointToLatLng(layerPoint),
-                relatedTarget = me._showLocation.relatedTarget,
+                relatedTarget = me._showLocation.relatedTarget || map,
                 data = {
                   containerPoint: containerPoint,
                   layerPoint: layerPoint,


### PR DESCRIPTION
I have a use case where a map based context menu item callback function is coming from another source file that does not have access to the actual Leaflet map object.

Defaulting the event relatedTarget to the original map solve this issue.
Another solution would be to have an extra property like target that would would always point to the original map object.